### PR TITLE
missed changes for 1hr to 30min

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -110,9 +110,9 @@ defmodule RunElixir.MixProject do
     <meta name="msapplication-TileColor" content="#9f00a7">
     <meta name="theme-color" content="#ffffff">
 
-    <meta property="og:title" content="RunElixir.com - The Free 1 Hour Intro to Elixir">
+    <meta property="og:title" content="RunElixir.com - The Free 30min Intro to Elixir">
     <meta property="og:image" content="https://runelixir.com/images/social-share.jpg">
-    <meta property="og:description" content="Interested in Elixir? This quickstart guide teaches you the basics and gets you coding in 1 hour.">
+    <meta property="og:description" content="Interested in Elixir? This quickstart guide teaches you the basics and gets you coding in 30 minutes.">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:creator" content="@PJUllrich">
 


### PR DESCRIPTION
Someone shared this with me via Slack and I noticed the description and title said "1 hour" while the image said "30min".  This change fixes it so it's consistently "30min".