### PR TITLE
tell asdf which erlang and elixir versions to use

### DIFF
--- a/guides/welcome.md
+++ b/guides/welcome.md
@@ -17,9 +17,11 @@ asdf plugin add erlang
 
 # Now install erlang
 asdf install erlang latest
+asdf global erlang latest
 
 # And Elixir
 asdf install elixir latest
+asdf global elixir latest
 
 # You can check that Elixir is installed with:
 elixir -v


### PR DESCRIPTION
When I tried the instructions as-is, I got the following:
```
% elixir -v
No version is set for command elixir
Consider adding one of the following versions in your config file at 
elixir 1.17.2-otp-27
```

The suggested changes tell `asdf` which versions to use and now I'm able to run `elixir -v` and `iex` with no issue.
