### PR TITLE
Update maps.livemd to use colon instead of semicolon

### DIFF
--- a/guides/01-basics/maps.livemd
+++ b/guides/01-basics/maps.livemd
@@ -31,7 +31,7 @@ Map.drop(map, [:hello, 32])
 
 ### Maps with Atom keys
 
-If your map contains only Atom keys, you can replace the arrow `=>` with a semicolon `:`
+If your map contains only Atom keys, you can replace the arrow `=>` with a colon `:`
 
 ```elixir
 map = %{hello: "World", age: 32, height: 190.47}


### PR DESCRIPTION
Instead of semicolon `;`, use `colon` as it is a punctuation mark (:) used to precede a list of items, a quotation, or an expansion or explanation.