### PR TITLE
Fix elixir-lang.org link to be treated as absolute, not relative.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # RunElixir - A Quickstart Guide to Elixir
 
-This project intends to give a 30min quickstart to the [Elixir](elixir-lang.org) programming language.
+This project intends to give a 30min quickstart to the [Elixir](https://elixir-lang.org/) programming language.
 
 You can find the latest version at [RunElixir.com](https://runelixir.com)
 


### PR DESCRIPTION
Set the link to `elixir-lang.org` to be absolute, including the scheme/protocol, to potentially save a human from reaching GitHub's "404 - page not found" page.