### PR TITLE
Update asdf commands on welcome page to match asdf 16.0

### DIFF
--- a/guides/welcome.md
+++ b/guides/welcome.md
@@ -17,11 +17,11 @@ asdf plugin add erlang
 
 # Now install erlang
 asdf install erlang latest
-asdf global erlang latest
+asdf set -u erlang latest
 
 # And Elixir
 asdf install elixir latest
-asdf global elixir latest
+asdf set -u elixir latest
 
 # You can check that Elixir is installed with:
 elixir -v


### PR DESCRIPTION
After asdf was rewritten in go some commands were changed or removed, including global and local, they were superseded by `asdf set -u` and `asdf set` respectively.